### PR TITLE
Use Python 3.9 in dockerfile

### DIFF
--- a/pyppeteer.Dockerfile
+++ b/pyppeteer.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.9-slim
 # Install system libraries for Python packages:
 # * psycopg2
 RUN apt-get update && \


### PR DESCRIPTION
This works perfectly for me locally, but fails when I try to run it in CI using the Docker image. https://github.com/dandi/dandi-archive/runs/5743060895?check_suite_focus=true

I suspect this is happening because DANDI uses Python 3.9, while the Docker image uses Python 3.8. @dchiquito do you see any issues with using 3.9 in the Docker image?